### PR TITLE
bump to go 1.21.1 to fix import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,14 @@
 module github.com/zhaobingss/gorm-sqlcipher
 
-go 1.14
+go 1.21.1
 
 require (
-	github.com/mutecomm/go-sqlcipher/v4 v4.4.2 // indirect
 	github.com/zhaobingss/go-sqlcipher/v4 v4.4.3
 	gorm.io/gorm v1.25.2
+)
+
+require (
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/mutecomm/go-sqlcipher/v4 v4.4.2 // indirect
 )


### PR DESCRIPTION
Currently the pkg is broken on newer Go versions resulting in this error:
```
# github.com/zhaobingss/gorm-sqlcipher
../../../../go/pkg/mod/github.com/zhaobingss/gorm-sqlcipher@v0.0.3/sqlite.go:84:22: invalid operation: limit.Limit > 0 (mismatched types *int and untyped int)
../../../../go/pkg/mod/github.com/zhaobingss/gorm-sqlcipher@v0.0.3/sqlite.go:86:39: cannot use limit.Limit (variable of type *int) as int value in argument to strconv.Itoa
../../../../go/pkg/mod/github.com/zhaobingss/gorm-sqlcipher@v0.0.3/sqlite.go:89:23: invalid operation: limit.Limit > 0 (mismatched types *int and untyped int)
```

bumping the Go version fixes the issue